### PR TITLE
Fix. Rename Avni to Offline in Bahmni metadata

### DIFF
--- a/masterdata/configuration/attributetypes/attribute_types.csv
+++ b/masterdata/configuration/attributetypes/attribute_types.csv
@@ -1,5 +1,5 @@
 Uuid,Void/Retire,Entity name,Name,Description,Min occurs,Max occurs,Datatype classname,Datatype config,Preferred handler classname,Handler config,_order:1000
 ,,Location,LGD Code,LGD Code of location.,0,,org.openmrs.customdatatype.datatype.FloatDatatype,,,,
 ,,Provider,Login Locations,"Name of the facility which the user needs to be assigned ",0,,org.openmrs.customdatatype.datatype.LocationDatatype,,,,
-164940ee-00a4-11ee-be56-0242ac120002,,Visit,Avni UUID,Stores UUID from Avni,0,,org.openmrs.customdatatype.datatype.FreeTextDatatype,,,,
-a6cfce26-00a4-11ee-be56-0242ac120002,,Visit,Avni Date,Stores date from Avni,0,,org.openmrs.customdatatype.datatype.DateDatatype,,,,
+164940ee-00a4-11ee-be56-0242ac120002,,Visit,Offline UUID,Stores UUID from Offline,0,,org.openmrs.customdatatype.datatype.FreeTextDatatype,,,,
+a6cfce26-00a4-11ee-be56-0242ac120002,,Visit,Offline Date,Stores date from Offline,0,,org.openmrs.customdatatype.datatype.DateDatatype,,,,

--- a/masterdata/configuration/concepts/avniConcepts.csv
+++ b/masterdata/configuration/concepts/avniConcepts.csv
@@ -1,6 +1,6 @@
 Uuid,Void/Retire,Same as mappings,Fully specified name:en,Short name:en,Description:en,Data class,Data type,Answers,Members,_version:1,_order:10000
-e2643ed2-0099-11ee-be56-0242ac120002,,,Avni UUID,Avni UUID,,Misc,Text,,,,
-930fce86-009a-11ee-be56-0242ac120002,,,Avni Dates,Avni Dates,,Misc,Text,,,,
-c0945160-009a-11ee-be56-0242ac120002,,,Avni Program Data,Avni Program,,Misc,Text,,,,
-36afac18-009c-11ee-be56-0242ac120002,,,Avni Registration Form,Avni Registration,,Misc,N/A,,Avni UUID;Avni Dates,,
+e2643ed2-0099-11ee-be56-0242ac120002,,,Offline UUID,Offline UUID,,Misc,Text,,,,
+930fce86-009a-11ee-be56-0242ac120002,,,Offline Dates,Offline Dates,,Misc,Text,,,,
+c0945160-009a-11ee-be56-0242ac120002,,,Offline Program Data,Offline Program Data,,Misc,Text,,,,
+36afac18-009c-11ee-be56-0242ac120002,,,Offline Registration Form,Offline Registration Form,,Misc,N/A,,Offline UUID;Offline Dates,,
 7daf07f2-00ed-11ee-be56-0242ac120002,,,Basic Vitals Form,Basic Vitals Form,,Misc,N/A,,9bb0795c-4ff0-0305-1990-000000000020;5242AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;5086AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,,

--- a/masterdata/configuration/conceptsets/conceptsets.csv
+++ b/masterdata/configuration/conceptsets/conceptsets.csv
@@ -1,3 +1,3 @@
 Concept,Member,Member Type,Sort Weight,_version:1,_order:1000
-All Observation Templates,Avni Registration Form,CONCEPT-SET,1.0,,
+All Observation Templates,Offline Registration Form,CONCEPT-SET,1.0,,
 All Observation Templates,Basic Vitals Form,CONCEPT-SET,2.0,,

--- a/masterdata/configuration/encounterroles/encounterroles.csv
+++ b/masterdata/configuration/encounterroles/encounterroles.csv
@@ -1,2 +1,2 @@
 Uuid,Void/Retire,Name,Description
-54ce9816-1062-4636-af95-655066cd6aba,,AvniEncounterRole,Used by Avni Integration System
+54ce9816-1062-4636-af95-655066cd6aba,,OfflineEncounterRole,Used by Offline Integration System

--- a/masterdata/configuration/encountertypes/encountertypes.csv
+++ b/masterdata/configuration/encountertypes/encountertypes.csv
@@ -1,2 +1,2 @@
 Uuid,Void/Retire,Name,Description,View privilege,Edit privilege,display:en,_order:1000
-ca87c010-00a6-11ee-be56-0242ac120002,,Community Registration Encounter,Registration Encounters made from Avni,,,,,
+ca87c010-00a6-11ee-be56-0242ac120002,,Community Registration Encounter,Registration Encounters made from Offline App,,,,,

--- a/masterdata/configuration/visittypes/visittypes.csv
+++ b/masterdata/configuration/visittypes/visittypes.csv
@@ -2,4 +2,4 @@ Uuid,Void/Retire,Name,Description,_version:1
 ,,OPD New,New Visit for Out patient,
 ,,OPD Review,Review Visit for Out patient,
 ,True,LAB VISIT,Visits for lab visit by patient when the tests are not ordered through OpenMRS,
-d57ff862-dda2-41ff-b607-9dd97a5e3039,,Community Visit,Visits happening in Community from Avni,
+d57ff862-dda2-41ff-b607-9dd97a5e3039,,Community Visit,Visits happening in Community from Offline App,

--- a/openmrs/apps/home/whiteLabel.json
+++ b/openmrs/apps/home/whiteLabel.json
@@ -35,7 +35,7 @@
       "linkPrefix": "erp"
     },
     {
-      "enabled": true,
+      "enabled": false,
       "name": "crater",
       "title": "Payment & Billing",
       "logo": "/bahmni/images/bills.png",
@@ -56,7 +56,7 @@
       "link": "/dcm4chee-web3"
     },
     {
-      "enabled": true,
+      "enabled": false,
       "name": "metabase",
       "title": "Analytics",
       "logo": "/bahmni/images/analytics.png",


### PR DESCRIPTION
This PR renames all Avni related concept names to `Offline`. Also disabled Crater and Analytics from the Bahmni Home page.