### PR TITLE
GOK-381 | Add a readonly field for ABHA Creation Error

### DIFF
--- a/avni-metadata/concepts.json
+++ b/avni-metadata/concepts.json
@@ -15,6 +15,11 @@
   "active" : true,
   "keyValues" : [ ]
 }, {
+  "name" : "ABHA Creation Error",
+  "uuid" : "c435e4a4-2c12-49ea-943f-e3e2b5e1073d",
+  "dataType" : "Text",
+  "active" : true
+}, {
   "name" : "ABHA Number",
   "uuid" : "e47be326-fad5-46ff-a0b8-e76c393b146f",
   "dataType" : "Text",

--- a/avni-metadata/forms/Patient Registration.json
+++ b/avni-metadata/forms/Patient Registration.json
@@ -174,6 +174,45 @@
         "descriptionKey" : "Phone Number should be 10 digits"
       },
       "mandatory" : true
+    }, {
+      "name" : "ABHA Creation Error",
+      "uuid" : "41305c8c-44c7-47ac-8ebe-2b985305fab2",
+      "keyValues" : [ {
+        "key" : "editable",
+        "value" : false
+      } ],
+      "concept" : {
+        "name" : "ABHA Creation Error",
+        "uuid" : "c435e4a4-2c12-49ea-943f-e3e2b5e1073d",
+        "dataType" : "Text",
+        "answers" : [ ],
+        "active" : true
+      },
+      "displayOrder" : 11.0,
+      "type" : "SingleSelect",
+      "rule" : "'use strict';\n({params, imports}) => {\n  const individual = params.entity;\n  const moment = imports.moment;\n  const formElement = params.formElement;\n  const _ = imports.lodash;\n  let visibility = true;\n  let value = null;\n  let answersToSkip = [];\n  let validationErrors = [];\n  \n  const condition11 = new imports.rulesConfig.RuleCondition({individual, formElement}).when.valueInRegistration(\"c435e4a4-2c12-49ea-943f-e3e2b5e1073d\").defined.matches();\n  \n  visibility = condition11 ;\n  \n  return new imports.rulesConfig.FormElementStatus(formElement.uuid, visibility, value, answersToSkip, validationErrors);\n};",
+      "declarativeRule" : [ {
+        "actions" : [ {
+          "actionType" : "showFormElement"
+        }, { } ],
+        "conditions" : [ {
+          "compoundRule" : {
+            "rules" : [ {
+              "lhs" : {
+                "type" : "concept",
+                "scope" : "registration",
+                "conceptName" : "ABHA Creation Error",
+                "conceptUuid" : "c435e4a4-2c12-49ea-943f-e3e2b5e1073d",
+                "conceptDataType" : "Text"
+              },
+              "rhs" : { },
+              "operator" : "defined"
+            } ],
+            "conjunction" : "and"
+          }
+        } ]
+      } ],
+      "mandatory" : false
     } ],
     "timed" : false
   } ],

--- a/avni-metadata/organisationConfig.json
+++ b/avni-metadata/organisationConfig.json
@@ -1,7 +1,7 @@
 {
   "uuid" : "cb833268-4ead-4c08-8f59-27583d740978",
   "settings" : {
-    "useMinioForStorage" : "true",
+    "useMinioForStorage" : true,
     "languages" : [ "en" ],
     "customRegistrationLocations" : [ ],
     "enableMobileAppDbEncryption" : true,


### PR DESCRIPTION
This PR adds a field in registration second page which is used to display error messages for ABHA creation errors.